### PR TITLE
Fix French translation

### DIFF
--- a/privacypolice/src/main/res/values-fr/strings.xml
+++ b/privacypolice/src/main/res/values-fr/strings.xml
@@ -3,26 +3,26 @@
 
     <string name="app_name">Wi-Fi Privacy Police</string>
     <string name="pref_onlyavailable">Protection de la vie privée</string>
-    <string name="pref_onlyavailable_summ">Empêche que d'autres personnes puissent accéder à la liste des points d'accès connus</string>
+    <string name="pref_onlyavailable_summ">Empêche que d\'autres personnes puissent accéder à la liste des points d\'accès connus</string>
     <string name="pref_onlyknown">Protection des données</string>
-    <string name="pref_onlyknown_summ">N'autoriser que les connexions aux points d'accès de confiance (une confirmation vous sera demandée lors de la première connexion)</string>
+    <string name="pref_onlyknown_summ">N\'autoriser que les connexions aux points d\'accès de confiance (une confirmation vous sera demandée lors de la première connexion)</string>
     <string name="ask_permission">Faites vous confiance au réseau "%1$s" ?</string>
     <string name="yes">Oui</string>
     <string name="no">Non</string>
     <string name="permission_header">\"%1$s\" rencontré</string>
     <string name="action_settings">Paramètres</string>
     <string name="info_string">Wi-Fi Privacy Police continue de vous protéger en arrière plan. Vous pouvez fermer cette fenêtre.</string>
-    <string name="clear_hotspots">Supprimer tous les points d'accès</string>
-    <string name="clear_hotspots_summ">Cliquez ici pour vider votre liste de points d'accès</string>
-    <string name="dialog_clearhotspots">Êtes vous sûr de vouloir vider la liste de points d'accès ? Wi-Fi Privacy Police vous redemandera confirmation lors de la première connexion à chaque point d'accès</string>
+    <string name="clear_hotspots">Supprimer tous les points d\'accès</string>
+    <string name="clear_hotspots_summ">Cliquez ici pour vider votre liste de points d\'accès</string>
+    <string name="dialog_clearhotspots">Êtes vous sûr de vouloir vider la liste de points d\'accès ? Wi-Fi Privacy Police vous redemandera confirmation lors de la première connexion à chaque point d\'accès</string>
     <string name="dialog_clearhotspots_yes">Vider</string>
     <string name="dialog_clearhotspots_no">Annuler</string>
-    <string name="dialog_clearhotspotsformac">Êtes vous sûr de vouloir retirer tous les points d'accès du réseau \"%1$s\" ?</string>
-    <string name="pref_tracking">Activer l'envoi de statistiques anonymes</string>
-    <string name="pref_tracking_summ">Activer cette option nous aidera pour de futurs travaux en envoyant périodiquement des données anonymisées, comme par exemple si vous vous servez encore de l'application. Nous ne collectons pas d'informations personnelles telles que les noms des points d'accès.</string>
-    <string name="modify_hotspots">Points d'accès connus</string>
-    <string name="modify_hotspots_summ">Retirer des points d'accès de la liste de confiance ou de la liste des points d'accès bloqués (expert)</string>
-    <string name="dialog_removetrustedmac">Êtes vous sûr de vouloir retirer le point d'accès \"%1$s\" de cette liste ?</string>
+    <string name="dialog_clearhotspotsformac">Êtes vous sûr de vouloir retirer tous les points d\'accès du réseau \"%1$s\" ?</string>
+    <string name="pref_tracking">Activer l\'envoi de statistiques anonymes</string>
+    <string name="pref_tracking_summ">Activer cette option nous aidera pour de futurs travaux en envoyant périodiquement des données anonymisées, comme par exemple si vous vous servez encore de l\'application. Nous ne collectons pas d\'informations personnelles telles que les noms des points d\'accès.</string>
+    <string name="modify_hotspots">Points d\'accès connus</string>
+    <string name="modify_hotspots_summ">Retirer des points d\'accès de la liste de confiance ou de la liste des points d\'accès bloqués (expert)</string>
+    <string name="dialog_removetrustedmac">Êtes vous sûr de vouloir retirer le point d\'accès \"%1$s\" de cette liste ?</string>
     <string name="dialog_remove">Retirer</string>
 
 </resources>

--- a/privacypolice/src/main/res/values-fr/strings.xml
+++ b/privacypolice/src/main/res/values-fr/strings.xml
@@ -6,7 +6,7 @@
     <string name="pref_onlyavailable_summ">Empêche que d\'autres personnes puissent accéder à la liste des points d\'accès connus</string>
     <string name="pref_onlyknown">Protection des données</string>
     <string name="pref_onlyknown_summ">N\'autoriser que les connexions aux points d\'accès de confiance (une confirmation vous sera demandée lors de la première connexion)</string>
-    <string name="ask_permission">Faites vous confiance au réseau "%1$s" ?</string>
+    <string name="ask_permission">Faites vous confiance au réseau "%1$s"\u00a0?</string>
     <string name="yes">Oui</string>
     <string name="no">Non</string>
     <string name="permission_header">\"%1$s\" rencontré</string>
@@ -14,15 +14,15 @@
     <string name="info_string">Wi-Fi Privacy Police continue de vous protéger en arrière plan. Vous pouvez fermer cette fenêtre.</string>
     <string name="clear_hotspots">Supprimer tous les points d\'accès</string>
     <string name="clear_hotspots_summ">Cliquez ici pour vider votre liste de points d\'accès</string>
-    <string name="dialog_clearhotspots">Êtes vous sûr de vouloir vider la liste de points d\'accès ? Wi-Fi Privacy Police vous redemandera confirmation lors de la première connexion à chaque point d\'accès</string>
+    <string name="dialog_clearhotspots">Êtes vous sûr de vouloir vider la liste de points d\'accès\u00a0? Wi-Fi Privacy Police vous redemandera confirmation lors de la première connexion à chaque point d\'accès</string>
     <string name="dialog_clearhotspots_yes">Vider</string>
     <string name="dialog_clearhotspots_no">Annuler</string>
-    <string name="dialog_clearhotspotsformac">Êtes vous sûr de vouloir retirer tous les points d\'accès du réseau \"%1$s\" ?</string>
+    <string name="dialog_clearhotspotsformac">Êtes vous sûr de vouloir retirer tous les points d\'accès du réseau \"%1$s\"\u00a0?</string>
     <string name="pref_tracking">Activer l\'envoi de statistiques anonymes</string>
     <string name="pref_tracking_summ">Activer cette option nous aidera pour de futurs travaux en envoyant périodiquement des données anonymisées, comme par exemple si vous vous servez encore de l\'application. Nous ne collectons pas d\'informations personnelles telles que les noms des points d\'accès.</string>
     <string name="modify_hotspots">Points d\'accès connus</string>
     <string name="modify_hotspots_summ">Retirer des points d\'accès de la liste de confiance ou de la liste des points d\'accès bloqués (expert)</string>
-    <string name="dialog_removetrustedmac">Êtes vous sûr de vouloir retirer le point d\'accès \"%1$s\" de cette liste ?</string>
+    <string name="dialog_removetrustedmac">Êtes vous sûr de vouloir retirer le point d\'accès \"%1$s\" de cette liste\u00a0?</string>
     <string name="dialog_remove">Retirer</string>
 
 </resources>


### PR DESCRIPTION
Fix AAPT errors when reading French translation from c28808275d71e2693234489d1332c7982fd7d5d8 `values-fr\values.xml:8: error: Apostrophe not preceded by \`
Make use of non-breaking space to avoid unexpected wrapping.