### PR TITLE
Add preference to relax data protection for EAP

### DIFF
--- a/privacypolice/src/main/java/be/uhasselt/privacypolice/PreferencesActivity.java
+++ b/privacypolice/src/main/java/be/uhasselt/privacypolice/PreferencesActivity.java
@@ -26,6 +26,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.wifi.WifiManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
@@ -61,6 +62,9 @@ public class PreferencesActivity extends Activity {
 
             // Load the preferences from an XML resource
             addPreferencesFromResource(R.xml.preferences);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                findPreference(PreferencesStorage.TRUST_EAP_ACCESS_POINTS).setEnabled(true);
+            }
             try {
                 SharedPreferences prefs = getPreferenceManager().getSharedPreferences();
                 prefs.registerOnSharedPreferenceChangeListener(this);

--- a/privacypolice/src/main/java/be/uhasselt/privacypolice/PreferencesStorage.java
+++ b/privacypolice/src/main/java/be/uhasselt/privacypolice/PreferencesStorage.java
@@ -41,7 +41,6 @@ public class PreferencesStorage {
     // String used to identify MAC addresses of allowed access points
     private final String ALLOWED_BSSID_PREFIX = "ABSSID//";
     private final String BLOCKED_BSSID_PREFIX = "BBSSID//";
-
     public PreferencesStorage(Context ctx) {
         this.prefs = PreferenceManager.getDefaultSharedPreferences(ctx);
         this.wifiManager =  (WifiManager) ctx.getSystemService(Context.WIFI_SERVICE);
@@ -52,12 +51,19 @@ public class PreferencesStorage {
         }
     }
 
+
+    public static final String TRUST_EAP_ACCESS_POINTS = "trustEapAccessPoints";
+
     public boolean getEnableOnlyAvailableNetworks() {
         return prefs.getBoolean("enableOnlyAvailableNetworks", true);
     }
 
     public boolean getOnlyConnectToKnownAccessPoints() {
         return prefs.getBoolean("onlyConnectToKnownAccessPoints", false);
+    }
+
+    public boolean getTrustEap() {
+        return prefs.getBoolean(TRUST_EAP_ACCESS_POINTS, false);
     }
 
     /**

--- a/privacypolice/src/main/res/values/strings.xml
+++ b/privacypolice/src/main/res/values/strings.xml
@@ -24,5 +24,7 @@
     <string name="modify_hotspots_summ">Remove hotspots from your list of trusted and blocked hotspots (advanced)</string>
     <string name="dialog_removetrustedmac">Are you sure you want to remove hotspot \"%1$s\"?</string>
     <string name="dialog_remove">Remove</string>
+    <string name="pref_trustEapAccessPoints">Relax data protection for EAP hotspots</string>
+    <string name="pref_trustEapAccessPoints_summ">Remove requirement for explicit MAC address whitelisting for EAP hotspots matching a known EAP configuration</string>
 
 </resources>

--- a/privacypolice/src/main/res/xml/preferences.xml
+++ b/privacypolice/src/main/res/xml/preferences.xml
@@ -15,6 +15,16 @@
         android:defaultValue="false"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
+    <SwitchPreference
+        android:key="trustEapAccessPoints"
+        android:title="@string/pref_trustEapAccessPoints"
+        android:summary="@string/pref_trustEapAccessPoints_summ"
+        android:dependency="onlyConnectToKnownAccessPoints"
+        android:defaultValue="false"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        />
     <!--CheckBoxPreference
         android:key="trackingAllowed"
         android:title="@string/pref_tracking"


### PR DESCRIPTION
Tentative implementation for #14 - needs review + testing

Implementation is currently very simple: as long as EAP is detected on ScanResult + WifiConfiguration, the network is expected to be allowed if option is enabled.