### PR TITLE
Typo fix in Location info

### DIFF
--- a/privacypolice/src/main/res/values/strings.xml
+++ b/privacypolice/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
     <string name="dialog_remove">Remove</string>
     <string name="location_permission_header">Location access disabled</string>
     <string name="location_permission_explanation">Wi-Fi PrivacyPolice might need (limited) location access in order to function correctly. Click here for more info.</string>
-    <string name="location_permission_full_explanation">Starting with Android version 6.0 (Marshmallow), apps can only view the list of Wi-Fi networks that are in range while location access is enabled. Your mileage may vary (depending on the device you\'re using, this might not be the case), but if you experience problems when using Wi-Fi PrivacyPolice, consider enabling location access. Coarse location access (only using Wi-Fi networks and cell towers, and not your actual GPS chip) should be sufficient.</string>
+    <string name="location_permission_full_explanation">Starting with Android version 5.0 (Lollipop), apps can only view the list of Wi-Fi networks that are in range while location access is enabled. Your mileage may vary (depending on the device you\'re using, this might not be the case), but if you experience problems when using Wi-Fi PrivacyPolice, consider enabling location access. Coarse location access (only using Wi-Fi networks and cell towers, and not your actual GPS chip) should be sufficient.</string>
     <string name="location_open_settings">Open location settings</string>
     <string name="pref_locationnotice">Show location notice</string>
     <string name="pref_locationnotice_summ">Remind me via a notification when coarse location access is disabled</string>


### PR DESCRIPTION
According to the source this applies to [SDK >21, so 5.0 (Lollipop)](https://github.com/BramBonne/privacypolice/blob/6383c249d8391489cb14d3f0a3e73c8126162775/privacypolice/src/main/java/be/uhasselt/privacypolice/LocationAccess.java#L29)

Either the text is wrong (so this PR fixes it) or the code needs to be `android.os.Build.VERSION.SDK_INT < 23`.