### PR TITLE
solve issue of low contrast

### DIFF
--- a/privacypolice/src/main/res/layout/activity_preferences.xml
+++ b/privacypolice/src/main/res/layout/activity_preferences.xml
@@ -9,6 +9,7 @@
         android:layout_height="wrap_content"
         android:text="@string/location_permission_explanation"
         android:id="@+id/location_notice"
+        android:textColor="#646464"
         android:background="#dcedc8"
         android:padding="@dimen/activity_horizontal_margin"
         android:visibility="gone"


### PR DESCRIPTION
The original text color of the component is '#656D5C', and the contrast between the text color ('#656D5C') and the background color ('#DCEDC8') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#646464') are as follows:
![image](https://user-images.githubusercontent.com/101503193/167428247-c2c224fc-20b2-43f4-8506-096f7b4e1d0b.png)

The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.